### PR TITLE
Add __stepname__ attribute to plugin __init__.

### DIFF
--- a/mapclientplugins/zincdatasourcestep/__init__.py
+++ b/mapclientplugins/zincdatasourcestep/__init__.py
@@ -19,6 +19,7 @@ This file is part of MAP Client. (http://launchpad.net/mapclient)
 '''
 __version__ = '0.1.0'
 __author__ = 'Hugh Sorby'
+__stepname__ = 'Zinc Data Source'
 
 # import class that derives itself from the step mountpoint.
 import mapclientplugins.zincdatasourcestep.widgets.resources_rc


### PR DESCRIPTION
This attribute is used by the MAP-Client to keep track of all the currently installed plugins, without it a number of MAP-Client plugin manager methods do not function correctly.